### PR TITLE
Added tools for xpcs reprocessing

### DIFF
--- a/gladier_tools/xpcs/__init__.py
+++ b/gladier_tools/xpcs/__init__.py
@@ -1,23 +1,158 @@
-from gladier import GladierBaseTool
-
-
-
-__all__ = ['EigenCorr', 'ApplyQmap']
+from gladier.defaults import GladierDefaults
 
 from .corr import *
-from .apply_qmap import * 
+from .apply_qmap import *
+from gladier_tools.xpcs.custom_pilot import custom_pilot
+from gladier_tools.xpcs.plot import make_corr_plots
 
-EigenCorr = GladierBaseTool()
-EigenCorr.flow_definition = []
-EigenCorr.flow_input = eigen_corr_data
-EigenCorr.funcx_functions = [
+__all__ = ['EigenCorr', 'ApplyQmap', 'CustomPilot', 'MakeCorrPlots']
+
+
+class EigenCorr(GladierDefaults):
+
+    flow_definition = {
+      'Comment': 'Run Corr on an HDF IMM Pair',
+      'StartAt': 'Eigen Corr',
+      'States': {
+        'Eigen Corr': {
+          'Comment': 'Eigen Corr',
+          'Type': 'Action',
+          'ActionUrl': 'https://api.funcx.org/automate',
+          'ActionScope': 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all',
+          'Parameters': {
+              'tasks': [{
+                'endpoint.$': '$.input.funcx_endpoint_compute',
+                'func.$': '$.input.eigen_corr_funcx_id',
+                'payload.$': '$.input',
+            }]
+          },
+          'ResultPath': '$.result',
+          'WaitTime': 600,
+          'End': True
+        }
+      }
+    }
+
+    required_input = [
+        'proc_dir',
+        'imm_file',
+        'hdf_file',
+        'flags',
+        'flat_file',
+        'corr_loc',
+    ]
+
+    funcx_functions = [
         eigen_corr
     ]
 
-ApplyQmap = GladierBaseTool()
-ApplyQmap.flow_definition = []
-ApplyQmap.flow_input = apply_qmap_data
-ApplyQmap.funcx_functions = [
+
+class ApplyQmap(GladierDefaults):
+
+    flow_definition = {
+      'Comment': 'Update an HDF with a new qmap settings file',
+      'StartAt': 'ApplyQmap',
+      'States': {
+        'ApplyQmap': {
+          'Comment': 'Apply Qmap',
+          'Type': 'Action',
+          'ActionUrl': 'https://api.funcx.org/automate',
+          'ActionScope': 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all',
+          'Parameters': {
+              'tasks': [{
+                    'endpoint.$': '$.input.funcx_endpoint_compute',
+                    'func.$': '$.input.apply_qmap_funcx_id',
+                    'payload.$': '$.input',
+                }]
+          },
+          'ResultPath': '$.result',
+          'WaitTime': 600,
+          'End': True
+        }
+      }
+    }
+
+    required_input = [
+        'proc_dir',
+        'qmap_file',
+        'flat_file',
+    ]
+
+    funcx_functions = [
         apply_qmap
     ]
 
+
+class MakeCorrPlots(GladierDefaults):
+
+    flow_definition = {
+      'Comment': 'Generate plots for a corr run. REQUIRES globus-automation to be INSTALLED',
+      'StartAt': 'MakeCorrPlots',
+      'States': {
+        'MakeCorrPlots': {
+          'Comment': 'Plot the results of a corr run, given the result hdf file',
+          'Type': 'Action',
+          'ActionUrl': 'https://api.funcx.org/automate',
+          'ActionScope': 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all',
+          'Parameters': {
+              'tasks': [{
+                'endpoint.$': '$.input.funcx_endpoint_compute',
+                'func.$': '$.input.make_corr_plots_funcx_id',
+                'payload.$': '$.input',
+            }]
+          },
+          'ResultPath': '$.result',
+          'WaitTime': 600,
+          'End': True
+        }
+      }
+    }
+
+    required_input = [
+        'proc_dir',
+        'hdf_file',
+    ]
+
+    funcx_functions = [
+        make_corr_plots
+    ]
+
+
+class CustomPilot(GladierDefaults):
+
+    flow_definition = {
+      'Comment': 'Run Pilot and upload the result to search + petreldata',
+      'StartAt': 'CustomPilot',
+      'States': {
+        'CustomPilot': {
+          'Comment': 'Upload to petreldata, ingest to xpcs search index',
+          'Type': 'Action',
+          'ActionUrl': 'https://api.funcx.org/automate',
+          'ActionScope': 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all',
+          'Parameters': {
+              'tasks': [{
+                'endpoint.$': '$.input.funcx_endpoint_non_compute',
+                'func.$': '$.input.custom_pilot_funcx_id',
+                'payload.$': '$.input',
+            }]
+          },
+          'ResultPath': '$.result',
+          'WaitTime': 600,
+          'End': True
+        }
+      }
+    }
+
+    flow_input = {
+        'reprocessing_suffix': '_qmap',
+    }
+
+    required_input = [
+        'proc_dir',
+        'hdf_file',
+        'reprocessing_suffix',
+    ]
+
+    funcx_functions = [
+        custom_pilot
+    ]

--- a/gladier_tools/xpcs/apply_qmap.py
+++ b/gladier_tools/xpcs/apply_qmap.py
@@ -41,25 +41,31 @@ def apply_qmap(data):
     #     orig_data = h5py.File(orig_filename, "r")
     # else:
     #     raise(NameError('original file does not exist!!'))
+    def h5open(filename, mode):
+        try:
+            return h5py.File(filename, mode)
+        except OSError as ose:
+            raise FileNotFoundError(f'{filename} could not be opened for "{mode}": {str(ose)}')
     
-    orig_data = h5py.File(orig_filename, "r")
+    orig_data = h5open(orig_filename, "r")
 
     ## new parameters
-    qmap_data = h5py.File(qmap_filename, "r")
+    # return qmap_filename
+    qmap_data = h5open(qmap_filename, "r")
     
     ##file to be created
-    output_data = h5py.File(output_filename, "w-")
+    output_data = h5open(output_filename, "w-")
     
     # Copy /measurement from orig_data into outputfile /measurement
     orig_data.copy('/measurement', output_data)
 
-
-    # flatfield file for Lambda (only detector with flatfield right now)
-    if orig_data["/measurement/instrument/detector/manufacturer"].value == "LAMBDA":
-       flat_data = h5py.File(flat_filename,"r")
-       flat_data.copy("/flatField_transpose",output_data,name="/measurement/instrument/detector/flatfield")
-       flat_data.close()
-    
+    # DISABLED! Currently, adding a flat field is optional, and so this may not exist. We need to make the
+    # flow smart enough to know whether to transfer it in or not.
+    # # flatfield file for Lambda (only detector with flatfield right now)
+    # if orig_data["/measurement/instrument/detector/manufacturer"].value == "LAMBDA":
+    #    flat_data = h5py.File(flat_filename,"r")
+    #    flat_data.copy("/flatField_transpose",output_data,name="/measurement/instrument/detector/flatfield")
+    #    flat_data.close()
     output_data[entry+"/Version"] = "1.0"
     output_data[entry+"/analysis_type"] = "Multitau"
     #output_data[entry+"/analysis_type"] = "Twotime"

--- a/gladier_tools/xpcs/apply_qmap.py
+++ b/gladier_tools/xpcs/apply_qmap.py
@@ -5,6 +5,10 @@ def apply_qmap(data):
     import os
     import h5py
     import numpy as np
+    import json
+    with open(data['parameter_file']) as f:
+        data = json.load(f)
+
     for file_arg in ['proc_dir', 'hdf_file', 'qmap_file']:
         if not data.get(file_arg):
             raise ValueError(f'You need to provide {file_arg}')

--- a/gladier_tools/xpcs/apply_qmap.py
+++ b/gladier_tools/xpcs/apply_qmap.py
@@ -1,28 +1,40 @@
-apply_qmap_data = {
-        'proc_dir':'',
-        'input_data':'',
-        'qmap_file':'',
-        'flat_file':'',
-        'output_file':'',
-    }
+
 
 def apply_qmap(data):
     import math
     import os
     import h5py
     import numpy as np
+    for file_arg in ['proc_dir', 'hdf_file', 'qmap_file']:
+        if not data.get(file_arg):
+            raise ValueError(f'You need to provide {file_arg}')
+        if not os.path.exists(data[file_arg]):
+            raise ValueError(f'File or directory {data[file_arg]} does not exist!')
 
     ##minimal data inputs payload
     proc_dir = data.get('proc_dir', '')
     orig_filename = data.get('hdf_file', '')
     qmap_filename = data.get('qmap_file', '')
     flat_filename = data.get('flat_file','')
-    output_filename = data.get('output_file', '') ## NEW H5 FILE based on ORIG + QMAP
+    # output_filename = data.get('output_file', '') ## NEW H5 FILE based on ORIG + QMAP
     ##
     entry = data.get('entry', '/xpcs')
     entry_out='/exchange'
 
     os.chdir(proc_dir)
+    output_filename = orig_filename
+    hdf_name, ext = os.path.splitext(orig_filename)
+    orig_filename = f'{hdf_name}_original{ext}'
+    os.rename(output_filename, orig_filename)
+    # return orig_filename, output_filename
+
+    # # return proc_dir
+    # new_qmap_dir = os.path.join(proc_dir, f'{hdf_name}{suffix}')
+    # return new_qmap_dir
+    # if not os.path.exists(new_qmap_dir):
+    #     os.mkdir(new_qmap_dir)
+    # output_filename = os.path.join(new_qmap_dir, f'{hdf_name}{suffix}{ext}')
+    # return output_filename
 
     # Open the three .h5 files
     # if isfile(orig_filename):

--- a/gladier_tools/xpcs/apply_qmap.py
+++ b/gladier_tools/xpcs/apply_qmap.py
@@ -11,9 +11,9 @@ def apply_qmap(data):
 
     for file_arg in ['proc_dir', 'hdf_file', 'qmap_file']:
         if not data.get(file_arg):
-            raise ValueError(f'You need to provide {file_arg}')
+            return f'You need to provide {file_arg}'
         if not os.path.exists(data[file_arg]):
-            raise ValueError(f'File or directory {data[file_arg]} does not exist!')
+            return f'File or directory {data[file_arg]} does not exist!'
 
     ##minimal data inputs payload
     proc_dir = data.get('proc_dir', '')
@@ -191,5 +191,8 @@ def apply_qmap(data):
     orig_data.close()
     qmap_data.close()
     output_data.close()
+
+    # Remove the original, so we don't end up with a bunch of extra hdf files
+    os.unlink(orig_filename)
 
     return output_filename

--- a/gladier_tools/xpcs/apply_qmap.py
+++ b/gladier_tools/xpcs/apply_qmap.py
@@ -45,7 +45,7 @@ def apply_qmap(data):
         try:
             return h5py.File(filename, mode)
         except OSError as ose:
-            raise FileNotFoundError(f'{filename} could not be opened for "{mode}": {str(ose)}')
+            raise OSError(f'{filename} could not be opened for "{mode}": {str(ose)}') from None
     
     orig_data = h5open(orig_filename, "r")
 

--- a/gladier_tools/xpcs/corr.py
+++ b/gladier_tools/xpcs/corr.py
@@ -7,6 +7,9 @@ def eigen_corr(event):
     import subprocess
     from subprocess import PIPE
 
+    import json
+    with open(event['parameter_file']) as f:
+        event = json.load(f)
     ##minimal data inputs payload
 #    data_dir = event.get('data_dir','') #location of the IMM
     imm_file = event['imm_file'] # raw data

--- a/gladier_tools/xpcs/corr.py
+++ b/gladier_tools/xpcs/corr.py
@@ -1,11 +1,5 @@
-eigen_corr_data = {
-        'proc_dir':'',
-        'imm_file':'',
-        'hdf_file':'',
-        'flags':'',
-        'flat_file':'',
-        'corr_loc':'corr',
-    }
+from gladier.defaults import GladierDefaults
+
     
 def eigen_corr(event):
     import os

--- a/gladier_tools/xpcs/custom_pilot.py
+++ b/gladier_tools/xpcs/custom_pilot.py
@@ -1,0 +1,81 @@
+
+
+def custom_pilot(event):
+    import os
+    import json
+    import shutil
+    import datetime
+    from XPCS.tools.xpcs_metadata import gather
+    from pilot.client import PilotClient
+
+    # Do the last minute renaming before uploading.
+    # Split A001_Aerogel_1mm_att6_Lq0_001_0001-1000 and .hdf
+    dataset_name, extension = os.path.splitext(os.path.basename(event['hdf_file']))
+    # A001_Aerogel_1mm_att6_Lq0_001_0001-1000
+    old_dataset_directory = os.path.join(event['proc_dir'], os.path.dirname(event['hdf_file']))
+    # A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap
+    new_dataset_directory = os.path.join(event['proc_dir'], f'{dataset_name}{event["reprocessing_suffix"]}')
+    # A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap/A001_Aerogel_1mm_att6_Lq0_001_0001-1000.hdf'
+    old_hdf_name = os.path.join(new_dataset_directory, os.path.basename(event['hdf_file']))
+    # A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap/A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap.hdf
+    new_hdf_name = os.path.join(new_dataset_directory, f'{dataset_name}{event["reprocessing_suffix"]}{extension}')
+
+    os.rename(old_dataset_directory, new_dataset_directory)
+    os.rename(old_hdf_name, new_hdf_name)
+    hdf_file = new_hdf_name
+
+    # Generate metadata
+    upload_dir = os.path.dirname(hdf_file)
+    exp_name = os.path.basename(hdf_file).replace(".hdf", "")
+    metadata = gather(hdf_file)
+    metadata.update({
+            'description': f'{exp_name}: Automated data processing.',
+            'creators': [{'creatorName': '8-ID'}],
+            'publisher': 'Automate',
+            'title': exp_name,
+            'subjects': [{'subject': 'XPCS'}, {'subject': '8-ID'}],
+            'publicationYear': f'{datetime.datetime.now().year}',
+            'resourceType': {
+                'resourceType': 'Dataset',
+                'resourceTypeGeneral': 'Dataset'
+            }
+        })
+    extra_metadata = event.get('metadata', {}) or {}
+    metadata.update(extra_metadata)
+    # Create metadata file
+    # Some types have changed between search ingests, and they cause the search ingest
+    # to fail. Pop them so we don't get the search error.
+    for evil_key in ['exchange.partition_norm_factor']:
+        if evil_key in metadata.keys():
+            metadata.pop(evil_key)
+
+    # ONLY upload images, this is required for using the test server
+    # We can remove this when petrel is back up and running
+    # upload_dir = os.path.join(exp_dir, exp_name)
+    # if not os.path.exists(upload_dir):
+    #     os.mkdir(upload_dir)
+    # for image in [img for img in os.listdir(exp_dir) if img.endswith('.png')]:
+    #     shutil.copy(os.path.join(exp_dir, image), os.path.join(upload_dir, image))
+
+    pc = PilotClient()
+    assert pc.context.current == 'xpcs', 'Pilot Context is not XPCS!'
+    pc.project.current = 'xpcs-8id'
+
+    pc.upload(upload_dir, '/', metadata=metadata, dry_run=False, update=True, skip_analysis=True)
+    return f'Upload Successful: {os.path.basename(upload_dir)}'
+    # try:
+    #     result = pc.upload(upload_dir, '/', metadata=metadata, dry_run=False, update=True, skip_analysis=True)
+    #     # Remove some large keys from result, upload everything else
+    #     # return {k: v for k, v in result.items()
+    #     #         if k not in ['new_metadata', 'previous_metadata', 'upload']}
+    #     return f'Upload Successful: {os.path.basename(upload_dir)}'
+    # except Exception as e:
+    #     metadata_f = os.path.join(upload_dir, 'metadata.json')
+    #     with open(metadata_f, 'w+') as f:
+    #         f.write(json.dumps(metadata, indent=2))
+    #     # return {
+    #     #     'error': f'Failed to upload to search, likely a broken key. Metadata dumped.',
+    #     #     'metadata_filename': metadata_f,
+    #     #     'exception': str(e),
+    #     # }
+    #     return f'Upload Failed: {os.path.basename(upload_dir)}'

--- a/gladier_tools/xpcs/custom_pilot.py
+++ b/gladier_tools/xpcs/custom_pilot.py
@@ -9,17 +9,28 @@ def custom_pilot(event):
     from pilot.client import PilotClient
 
     # Do the last minute renaming before uploading.
+    # The proc dir is a ../A001_Aerogel_1mm_att6_Lq0_001_0001-1000
+    base_proc_dir = os.path.dirname(event['proc_dir'])
     # Split A001_Aerogel_1mm_att6_Lq0_001_0001-1000 and .hdf
     dataset_name, extension = os.path.splitext(os.path.basename(event['hdf_file']))
     # A001_Aerogel_1mm_att6_Lq0_001_0001-1000
-    old_dataset_directory = os.path.join(event['proc_dir'], os.path.dirname(event['hdf_file']))
+    old_dataset_directory = os.path.join(base_proc_dir, os.path.dirname(event['hdf_file']))
     # A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap
-    new_dataset_directory = os.path.join(event['proc_dir'], f'{dataset_name}{event["reprocessing_suffix"]}')
+    new_dataset_directory = os.path.join(base_proc_dir, f'{dataset_name}{event["reprocessing_suffix"]}')
     # A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap/A001_Aerogel_1mm_att6_Lq0_001_0001-1000.hdf'
     old_hdf_name = os.path.join(new_dataset_directory, os.path.basename(event['hdf_file']))
     # A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap/A001_Aerogel_1mm_att6_Lq0_001_0001-1000_qmap.hdf
     new_hdf_name = os.path.join(new_dataset_directory, f'{dataset_name}{event["reprocessing_suffix"]}{extension}')
 
+    # return {
+    #     'proc_dir': event['proc_dir'],
+    #     'hdf_file': event['hdf_file'],
+    #     'dataset_name': dataset_name,
+    #     'old_dataset_directory': old_dataset_directory,
+    #     'new_dataset_directory': new_dataset_directory,
+    #     'old_hdf_name': old_hdf_name,
+    #     'new_hdf_name': new_hdf_name,
+    # }
     os.rename(old_dataset_directory, new_dataset_directory)
     os.rename(old_hdf_name, new_hdf_name)
     hdf_file = new_hdf_name

--- a/gladier_tools/xpcs/custom_pilot.py
+++ b/gladier_tools/xpcs/custom_pilot.py
@@ -8,6 +8,10 @@ def custom_pilot(event):
     from XPCS.tools.xpcs_metadata import gather
     from pilot.client import PilotClient
 
+    import json
+    with open(event['parameter_file']) as f:
+        event = json.load(f)
+
     # Do the last minute renaming before uploading.
     # The proc dir is a ../A001_Aerogel_1mm_att6_Lq0_001_0001-1000
     base_proc_dir = os.path.dirname(event['proc_dir'])

--- a/gladier_tools/xpcs/plot.py
+++ b/gladier_tools/xpcs/plot.py
@@ -7,5 +7,8 @@ def make_corr_plots(event):
     import os
     from XPCS.tools import xpcs_plots
     os.chdir(os.path.join(event['proc_dir'], os.path.dirname(event['hdf_file'])))
-    xpcs_plots.make_plots(os.path.join(event['proc_dir'], event['hdf_file']))
+    try:
+        xpcs_plots.make_plots(os.path.join(event['proc_dir'], event['hdf_file']))
+    except (Exception, SystemExit) as e:
+        return str(e)
     return [img for img in os.listdir('.') if img.endswith('.png')]

--- a/gladier_tools/xpcs/plot.py
+++ b/gladier_tools/xpcs/plot.py
@@ -1,6 +1,9 @@
 
 
 def make_corr_plots(event):
+    import json
+    with open(event['parameter_file']) as f:
+        event = json.load(f)
     import os
     from XPCS.tools import xpcs_plots
     os.chdir(os.path.join(event['proc_dir'], os.path.dirname(event['hdf_file'])))

--- a/gladier_tools/xpcs/plot.py
+++ b/gladier_tools/xpcs/plot.py
@@ -1,0 +1,8 @@
+
+
+def make_corr_plots(event):
+    import os
+    from XPCS.tools import xpcs_plots
+    os.chdir(os.path.join(event['proc_dir'], os.path.dirname(event['hdf_file'])))
+    xpcs_plots.make_plots(os.path.join(event['proc_dir'], event['hdf_file']))
+    return [img for img in os.listdir('.') if img.endswith('.png')]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-gladier>=0.0.2
+gladier>=0.0.1.dev0


### PR DESCRIPTION
These include changes to tools to work with manifests and XPCS Reprocessing. I _don't_ think we'll want to keep some of these changes. Especially the edits to the funcx functions to cut down on input size. I'll add them for version 0.0.1 and then we can revert them for version 0.x.x