### PR TITLE
Remove earlier hack to reduce flow payload size

### DIFF
--- a/gladier_tools/xpcs/apply_qmap.py
+++ b/gladier_tools/xpcs/apply_qmap.py
@@ -5,9 +5,6 @@ def apply_qmap(data):
     import os
     import h5py
     import numpy as np
-    import json
-    with open(data['parameter_file']) as f:
-        data = json.load(f)
 
     for file_arg in ['proc_dir', 'hdf_file', 'qmap_file']:
         if not data.get(file_arg):

--- a/gladier_tools/xpcs/corr.py
+++ b/gladier_tools/xpcs/corr.py
@@ -7,11 +7,7 @@ def eigen_corr(event):
     import subprocess
     from subprocess import PIPE
 
-    import json
-    with open(event['parameter_file']) as f:
-        event = json.load(f)
     ##minimal data inputs payload
-#    data_dir = event.get('data_dir','') #location of the IMM
     imm_file = event['imm_file'] # raw data
     proc_dir = event['proc_dir'] # location of the HDF/QMAP process file / result
     hdf_file = event['hdf_file'] # name of the file to run EIGEN CORR

--- a/gladier_tools/xpcs/custom_pilot.py
+++ b/gladier_tools/xpcs/custom_pilot.py
@@ -8,10 +8,6 @@ def custom_pilot(event):
     from XPCS.tools.xpcs_metadata import gather
     from pilot.client import PilotClient
 
-    import json
-    with open(event['parameter_file']) as f:
-        event = json.load(f)
-
     # Do the last minute renaming before uploading.
     # The proc dir is a ../A001_Aerogel_1mm_att6_Lq0_001_0001-1000
     base_proc_dir = os.path.dirname(event['proc_dir'])

--- a/gladier_tools/xpcs/plot.py
+++ b/gladier_tools/xpcs/plot.py
@@ -1,9 +1,6 @@
 
 
 def make_corr_plots(event):
-    import json
-    with open(event['parameter_file']) as f:
-        event = json.load(f)
     import os
     from XPCS.tools import xpcs_plots
     os.chdir(os.path.join(event['proc_dir'], os.path.dirname(event['hdf_file'])))


### PR DESCRIPTION
This was a hack fix to mitigate the main problem with manifests --
they exhausted the max payload size in AWS step functions and caused
the flow to fail. With a non-manifests approach, where each dataset
has its own flow, we no longer need this.