### PR TITLE
Add unit test for tar function

### DIFF
--- a/gladier_tools/tests/posix/test_tar.py
+++ b/gladier_tools/tests/posix/test_tar.py
@@ -1,0 +1,15 @@
+from unittest.mock import Mock
+import tarfile
+from gladier_tools.posix.tar import tar
+
+
+def test_tar(monkeypatch):
+    mock_tf = Mock()
+    mock_open = Mock()
+    mock_open.return_value.__enter__ = Mock(return_value=mock_tf)
+    mock_open.return_value.__exit__ = Mock(return_value=None)
+    monkeypatch.setattr(tarfile, 'open', mock_open)
+    output_file = tar(tar_input='foo')
+    assert mock_open.called
+    assert mock_tf.add.called
+    assert output_file == 'foo.tgz'


### PR DESCRIPTION
I did a pass on adding tests to gladier tool functions. I wasn't sure how this would work out, since funcx-functions are a bit unique in how they import modules. Turns out this seems to make testing easier since modules won't be imported until they are called. Testing the Tar function above went pretty smoothly. 