### PR TITLE
refactor: Changed name of asym_decrypt to asymmetric_decrypt

### DIFF
--- a/gladier_tools/posix/asymmetric_decrypt.py
+++ b/gladier_tools/posix/asymmetric_decrypt.py
@@ -1,7 +1,7 @@
 from gladier import GladierBaseTool, generate_flow_definition
 
 
-def asym_decrypt(**data):
+def asymmetric_decrypt(**data):
     import os
     from cryptography.hazmat.primitives.serialization import \
         load_ssh_private_key
@@ -55,18 +55,18 @@ class AsymmetricDecrypt(GladierBaseTool):
     tools.
 
     :param private_key_path: Path to the id_rsa file which contains
-    the RSA private key. Defaults to ~/.ssh/id_rsa if not passed in.
+        the RSA private key. Defaults to ~/.ssh/id_rsa if not passed in.
     :param asym_decrypt_file: File which needs to be decrypted.
     :param funcx_endpoint_compute: By default, uses the ``compute``
-    funcx endpoint.
+        funcx endpoint.
     :param asym_decrypt_password: (Optional) If the private file is password
-    protected, pass it in through this argument.
+        protected, pass it in through this argument.
     :param output_file: (Optional) Path to the output file which holds the
-    decrypted contents.
+        decrypted contents.
     :returns output_path: Location of the decrypted file.
     """
 
-    funcx_functions = [asym_decrypt]
+    funcx_functions = [asymmetric_decrypt]
     required_input = [
         'private_key_path',
         'asym_decrypt_file',

--- a/gladier_tools/posix/asymmetric_encrypt.py
+++ b/gladier_tools/posix/asymmetric_encrypt.py
@@ -1,7 +1,7 @@
 from gladier import GladierBaseTool, generate_flow_definition
 
 
-def asym_encrypt(**data):
+def asymmetric_encrypt(**data):
     import os
     from cryptography.hazmat.primitives.serialization import \
         load_ssh_public_key
@@ -47,14 +47,14 @@ class AsymmetricEncrypt(GladierBaseTool):
     tools.
 
     :param public_key_path: Path to the .pub file which contains
-    the RSA public key. Defaults to ~/.ssh/id_rsa.pub
+        the RSA public key. Defaults to ~/.ssh/id_rsa.pub
     :param asym_encrypt_file: File which needs to be encrypted.
     :param funcx_endpoint_compute: By default, uses the ``compute``
-    funcx endpoint.
+        funcx endpoint.
     :returns output_path: Location of the encrypted file.
     """
 
-    funcx_functions = [asym_encrypt]
+    funcx_functions = [asymmetric_encrypt]
     required_input = [
         'public_key_path',
         'asym_encrypt_file',


### PR DESCRIPTION
The names weren't quite consistent with the class, which was named
AsymmetricDecrypt. Both the filename and the class name
should be consistent. I prefer having them spelled out, so I changed
to the full spelled out version.