### PR TITLE
Shell CMD: Error by default to stop the flow execution

### DIFF
--- a/gladier_tools/posix/shell_cmd.py
+++ b/gladier_tools/posix/shell_cmd.py
@@ -8,7 +8,7 @@ def shell_cmd(
     cwd=None,
     env=None,
     timeout=60,
-    exception_on_error=False,
+    exception_on_error=True,
     input_path=None,
     output_path=None,
     error_path=None,
@@ -119,7 +119,9 @@ def shell_cmd(
     return res.returncode, res.stdout, res.stderr
 
 
-@generate_flow_definition
+@generate_flow_definition(modifiers={
+    "shell_cmd": {"ExceptionOnActionFailure": True}
+})
 class ShellCmdTool(GladierBaseTool):
     funcx_functions = [shell_cmd]
     required_input = ["args"]

--- a/gladier_tools/posix/shell_cmd.py
+++ b/gladier_tools/posix/shell_cmd.py
@@ -15,7 +15,16 @@ def shell_cmd(
     **kwargs,
 ):
     """Run a command in a shell with various options. Suitable for use as a
-    funcx function.
+    funcx function. On anything other than exit success (returning 0), an
+    exception will be raised, the stack trace will be propogated, and the flow
+    will be halted. On exit success, the return code, stdout, and sterr are returned
+    in a list in the format:
+
+    [0, "Standard Output Text", "Standard Error Text"]
+
+    Note: stdout and sterr will always be None unless ``capture_output`` is set.
+
+
 
     Args:
         args: Arguments to the command. Can be either a list of strings
@@ -35,7 +44,7 @@ def shell_cmd(
             seconds.
         exception_on_error: If the command fails, should an exception be raised
             or should just the (presumably non-zero) return code be returned.
-            Defaults to False.
+            Defaults to True.
         input_path: A path to a file which should be used as the standard input
             to the command. When not provided, stdin does not exist so attempts
             to read from it will result in an error.

--- a/gladier_tools/tests/posix/test_shell_cmd.py
+++ b/gladier_tools/tests/posix/test_shell_cmd.py
@@ -43,11 +43,11 @@ cases = [
         expected_stdout="in_cmd pos1 pos2",
     ),
     Case(args="cat", expected_stdout="pytest", input_path=os.path.abspath(__file__)),
-    Case(args="NoT_ReallY_A_Cmd", expected_returncode=127),
+    Case(args="NoT_ReallY_A_Cmd", expected_exception=subprocess.CalledProcessError),
     Case(
         args="NoT_ReallY_A_Cmd",
-        exception_on_error=True,
-        expected_exception=subprocess.CalledProcessError,
+        exception_on_error=False,
+        expected_returncode=127,
     ),
     Case(
         args="echo $TEST_VAR", env={"TEST_VAR": "test_val"}, expected_stdout="test_val"


### PR DESCRIPTION
I think it makes a bit more sense as a default to have the flow halt on error, so failures are easier to debug. This simulates similar behavior as an action provider encountering an error and stopping the flow. Setting `exception_on_error=False` results in no exception, and causes the flow to complete successfully even when there are errors. 

It's out of scope for this PR, but I think `ExceptionOnActionFailure: True` makes more sense as a default for Gladier itself, and we should change that in a future release. Currently that's set to False, so an explicit value is needed. 