### PR TITLE
Shell CMD -- Add funcx endpoint as required input

### DIFF
--- a/gladier_tools/posix/shell_cmd.py
+++ b/gladier_tools/posix/shell_cmd.py
@@ -122,4 +122,4 @@ def shell_cmd(
 @generate_flow_definition
 class ShellCmdTool(GladierBaseTool):
     funcx_functions = [shell_cmd]
-    required_input = ["args"]
+    required_input = ["args", "funcx_endpoint_compute"]


### PR DESCRIPTION
Causes Gladier to raise an error if `funcx_endpoint_compute` isn't specified, otherwise this will fail during the flow. 