### PR TITLE
feat: Add guest collection support for publish tool

### DIFF
--- a/gladier_tools/tests/publish/test_publish.py
+++ b/gladier_tools/tests/publish/test_publish.py
@@ -20,7 +20,7 @@ def pilot_input():
 def mock_pilot(monkeypatch):
     mock_inst = Mock()
     mock_client = Mock(return_value=mock_inst)
-    mock_inst.get_globus_transfer_paths.return_value = [('src_path', 'dest_path')]
+    mock_inst.get_globus_transfer_paths.return_value = [('/src_path', 'dest_path')]
     monkeypatch.setattr(pilot.client, 'PilotClient', mock_client)
     return mock_client
 


### PR DESCRIPTION
The publish tool previously couldn't be used for guest collections which were configured with a relative POSIX path, due to the source collection always being incorrect. These changes allow an option to supply a guest collection basepath to fix the source paths before the transfer step takes place.