### PR TITLE
fix: Add recursive option to publish v2

### DIFF
--- a/gladier_tools/publish/publishv2.py
+++ b/gladier_tools/publish/publishv2.py
@@ -14,6 +14,7 @@ def publishv2_gather_metadata(
     metadata_file: str = None,
     source_collection_basepath: str = None,
     destination_url_hostname: str = None,
+    recursive_transfer: bool = True,
     checksum_algorithms: Tuple[str] = ("sha256", "sha512"),
     metadata_dc_validation_schema: str = None,
     enable_publish: bool = True,
@@ -235,6 +236,7 @@ def publishv2_gather_metadata(
                         source_collection_basepath, dataset
                     ),
                     "destination_path": str(destination_path),
+                    "recursive": recursive_transfer,
                 }
             ],
         },

--- a/gladier_tools/tests/publish/test_publishv2.py
+++ b/gladier_tools/tests/publish/test_publishv2.py
@@ -259,6 +259,7 @@ def test_publish_transfer(publish_input):
             {
                 "destination_path": str(pathlib.Path("/my-new-project") / dataset.name),
                 "source_path": str(dataset),
+                "recursive": True,
             }
         ],
     }


### PR DESCRIPTION
This problem seems odd to me, but transfer _should_ automatically detect recursive transfers and not require the extra boolean. It's odd to me why this suddenly started failing. Adding the extra option by default True does fix this for the common use-case where the entity being transferred is a directory.