### PR TITLE
fix: Publish v2 not properly picking up subdirectory files

### DIFF
--- a/gladier_tools/publish/publishv2.py
+++ b/gladier_tools/publish/publishv2.py
@@ -94,14 +94,20 @@ def publishv2_gather_metadata(
         if not dataset.exists():
             raise ValueError(f"File does not exist: {filepath}")
 
-        file_list = [dataset] if dataset.is_file() else list(dataset.iterdir())
+        if dataset.is_file():
+            file_list = [dataset]
+        else:
+            # Glob together all directories, then iterate over them for all files
+            file_list = [dir.iterdir() for dir in dataset.glob("**")]
+            file_list = [f for subgroup in file_list for f in subgroup]
         file_list = [
             (
                 local_abspath,
                 destination
                 / str(local_abspath.relative_to(dataset.parent)).lstrip("/"),
             )
-            for local_abspath in file_list if not local_abspath.is_dir()
+            for local_abspath in file_list
+            if not local_abspath.is_dir()
         ]
 
         manifest_entries = []

--- a/gladier_tools/tests/publish/test_publishv2.py
+++ b/gladier_tools/tests/publish/test_publishv2.py
@@ -47,9 +47,18 @@ def test_publish(publish_input):
     assert set(publishv2_gather_metadata(**publish_input)) == {"search", "transfer"}
 
 
-def test_publish(publish_input):
+def test_publish_nested_dataset(publish_input):
     publish_input["dataset"] = mock_data / "nested_dataset_folder"
-    assert set(publishv2_gather_metadata(**publish_input)) == {"search", "transfer"}
+    metadata = publishv2_gather_metadata(**publish_input)
+    assert set(metadata) == {"search", "transfer"}
+
+    files = metadata["search"]["content"]["files"]
+    assert len(files) == 2
+    urls = {f["url"] for f in files}
+    assert urls == {
+        "globus://my_globus_collection/my-new-project/nested_dataset_folder/bar.txt",
+        "globus://my_globus_collection/my-new-project/nested_dataset_folder/nested_folder/foo.txt",
+    }
 
 
 def test_json_serializable(publish_input):
@@ -275,7 +284,9 @@ def test_publish_collection_valid_basepath(publish_input):
     """Test Guest Collection basepath where the share point is the parent of the source
     dataset being published."""
     publish_input["source_collection_basepath"] = publish_input["dataset"].parent
-    source_file = publishv2_gather_metadata(**publish_input)["transfer"]["transfer_items"][0]
+    source_file = publishv2_gather_metadata(**publish_input)["transfer"][
+        "transfer_items"
+    ][0]
     assert source_file["source_path"] == f"/{publish_input['dataset'].name}"
 
 


### PR DESCRIPTION
If the dataset contained subdirectories, publish would not properly select them for publication.