### PR TITLE
fix: Update old transfer AP

### DIFF
--- a/gladier_tools/globus/transfer.py
+++ b/gladier_tools/globus/transfer.py
@@ -31,11 +31,11 @@ class Transfer(GladierBaseTool):
             'Transfer': {
                 'Comment': 'Transfer a file or directory in Globus',
                 'Type': 'Action',
-                'ActionUrl': 'https://actions.automate.globus.org/transfer/transfer',
+                'ActionUrl': 'https://transfer.actions.globus.org/transfer/',
                 'Parameters': {
-                    'source_endpoint_id.$': '$.input.transfer_source_endpoint_id',
-                    'destination_endpoint_id.$': '$.input.transfer_destination_endpoint_id',
-                    'transfer_items': [
+                    'source_endpoint.$': '$.input.transfer_source_endpoint_id',
+                    'destination_endpoint.$': '$.input.transfer_destination_endpoint_id',
+                    'DATA': [
                         {
                             'source_path.$': '$.input.transfer_source_path',
                             'destination_path.$': '$.input.transfer_destination_path',

--- a/gladier_tools/publish/publish.py
+++ b/gladier_tools/publish/publish.py
@@ -36,9 +36,9 @@ def publish_gather_metadata(**data):
                 'search_index': index
             },
             'transfer': {
-                'source_endpoint_id': data['source_globus_endpoint'],
-                'destination_endpoint_id': pc.get_endpoint(),
-                'transfer_items': [{
+                'source_endpoint': data['source_globus_endpoint'],
+                'destination_endpoint': pc.get_endpoint(),
+                'DATA': [{
                     'source_path': translate_guest_collection_path(source_collection_basepath, src),
                     'destination_path': dest,
                     # 'recursive': False,  # each file is explicit in pilot, no directories
@@ -136,7 +136,7 @@ class Publish(GladierBaseTool):
             'PublishTransfer': {
                 'Comment': 'Transfer files for publication',
                 'Type': 'Action',
-                'ActionUrl': 'https://actions.automate.globus.org/transfer/transfer',
+                'ActionUrl': 'https://transfer.actions.globus.org/transfer/',
                 'InputPath': '$.PublishGatherMetadata.details.results[0].output.transfer',
                 'ResultPath': '$.PublishTransfer',
                 'WaitTime': 600,

--- a/gladier_tools/publish/publishv2.py
+++ b/gladier_tools/publish/publishv2.py
@@ -234,9 +234,9 @@ def publishv2_gather_metadata(
             "search_index": index,
         },
         "transfer": {
-            "source_endpoint_id": source_collection,
-            "destination_endpoint_id": destination_collection,
-            "transfer_items": [
+            "source_endpoint": source_collection,
+            "destination_endpoint": destination_collection,
+            "DATA": [
                 {
                     "source_path": translate_guest_collection_path(
                         source_collection_basepath, dataset
@@ -376,7 +376,7 @@ class Publishv2(GladierBaseTool):
             "Publishv2Transfer": {
                 "Comment": "Transfer files for publication",
                 "Type": "Action",
-                "ActionUrl": "https://actions.automate.globus.org/transfer/transfer",
+                "ActionUrl": "https://transfer.actions.globus.org/transfer/",
                 "InputPath": "$.Publishv2GatherMetadata.details.results[0].output.transfer",
                 "ResultPath": "$.Publishv2Transfer",
                 "WaitTime": 600,

--- a/gladier_tools/tests/publish/test_publishv2.py
+++ b/gladier_tools/tests/publish/test_publishv2.py
@@ -3,7 +3,14 @@ from unittest import mock
 import pathlib
 import datetime
 import json
-from datacite import schema42, schema43
+import sys
+try:
+    from datacite import schema42, schema43
+except AttributeError:
+    if sys.version_info.major == 3 and sys.version_info.minor == 8:
+        print('Datacite broken on version 3.8, tests will be skipped.')
+    else:
+        raise
 from gladier_tools.publish.publishv2 import publishv2_gather_metadata
 
 mock_data = pathlib.Path(__file__).resolve().parent.parent / "mock_data/publish/"
@@ -117,12 +124,14 @@ def test_bad_metadata_file(publish_input):
         publishv2_gather_metadata(**publish_input)
 
 
+@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 8, reason="Datacite version broken")
 def test_validate_dc(publish_input):
     dc = publishv2_gather_metadata(**publish_input)["search"]["content"]["dc"]
     schema42.validator.validate(dc)
     schema43.validator.validate(dc)
 
 
+@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 8, reason="Datacite version broken")
 @pytest.mark.parametrize(
     "schema,metadata",
     [
@@ -171,6 +180,7 @@ def test_eval(schema, metadata, publish_input):
     publishv2_gather_metadata(**publish_input)
 
 
+@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 8, reason="Datacite version broken")
 def test_datacite_override(publish_input):
     extra_input = {
         "metadata": {"dc": {"creators": [{"name": "nick"}]}},
@@ -181,6 +191,7 @@ def test_datacite_override(publish_input):
     assert output["creators"] == [{"name": "nick"}]
 
 
+@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 8, reason="Datacite version broken")
 def test_datacite_validator(publish_input):
     extra_input = {
         "metadata": {"dc": {"authors": ["invalid_bob"]}},

--- a/gladier_tools/tests/publish/test_publishv2.py
+++ b/gladier_tools/tests/publish/test_publishv2.py
@@ -268,9 +268,9 @@ def test_publish_transfer(publish_input):
     output = publishv2_gather_metadata(**publish_input)
     dataset = publish_input["dataset"]
     assert output["transfer"] == {
-        "destination_endpoint_id": "my_globus_collection",
-        "source_endpoint_id": "my_transfer_endpoint",
-        "transfer_items": [
+        "destination_endpoint": "my_globus_collection",
+        "source_endpoint": "my_transfer_endpoint",
+        "DATA": [
             {
                 "destination_path": str(pathlib.Path("/my-new-project") / dataset.name),
                 "source_path": str(dataset),
@@ -285,7 +285,7 @@ def test_publish_collection_valid_basepath(publish_input):
     dataset being published."""
     publish_input["source_collection_basepath"] = publish_input["dataset"].parent
     source_file = publishv2_gather_metadata(**publish_input)["transfer"][
-        "transfer_items"
+        "DATA"
     ][0]
     assert source_file["source_path"] == f"/{publish_input['dataset'].name}"
 


### PR DESCRIPTION
The old transfer action provider will be removed Nov 13th. This updates to the newer one that should be used instead.